### PR TITLE
Fix uint32_t overflow that was causing glitched audio

### DIFF
--- a/gstav_adec.c
+++ b/gstav_adec.c
@@ -165,7 +165,7 @@ flac_header(struct obj *self, GstBuffer *buf)
 	return 1;
 }
 
-static inline uint32_t
+static inline uint64_t
 calculate_duration(struct obj *self, uint64_t size)
 {
 	uint32_t samples;


### PR DESCRIPTION
The following patch fixes a uint32_t overflow which happens with small sample rates.

Given the default buffer size (192000 bytes), and 8000Hz 1 channels s16 spec, the buffer duration is 12 seconds which is larger than UINT32_MAX. Because of an implicit cast in calculate_duration, it would return garbage values, which in turn means gst-av would push broken timestamps. This would confuse the audio sink, causing rather large skips.

This problem can be easily reproduced with some highly-compressed audio podcasts. See https://together.jolla.com/question/23341/garbled-playback-of-some-mp3s-with-builtin-player/

Thanks to @keithzg for documenting the problem and collecting testcases.
